### PR TITLE
Recovered IO file, because it has generics methods

### DIFF
--- a/EncounterMe/EncounterMe/Pins/IO.cs
+++ b/EncounterMe/EncounterMe/Pins/IO.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace EncounterMe
+{
+    static class IO
+    {
+        //public static void WriteToBinaryFile<T>(string filePath, T objectToWrite, bool append = true)
+        //{
+        //    using (Stream stream = File.Open(filePath, append ? FileMode.Append : FileMode.Create))
+        //    {
+        //        var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+
+        //        binaryFormatter.Serialize(stream, objectToWrite);
+        //    }
+        //}
+
+        //public static List<T> ReadFromBinaryFile<T>(string filePath)
+        //{
+        //    var list = new List<T>();
+
+        //    try
+        //    {
+        //        using (Stream stream = File.Open(filePath, FileMode.Open))
+        //        {
+        //            var binaryFormatter = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+
+        //            while (stream.Position < stream.Length)
+        //            {
+        //                T obj = (T)binaryFormatter.Deserialize(stream);
+        //                list.Add(obj);
+        //            }
+        //            return list;
+        //        }
+        //    }
+        //    catch (Exception)
+        //    {
+        //        return null;
+        //    }
+        //}
+    }
+}


### PR DESCRIPTION
Gražinau ištrintą IO klasę, kur vyksta rašymas/skaitymas iš failo, sutvarkiau, kad būtų tinkami generics methods reikalavimams. Kadangi mačiau kitos grupės irgi taip darė, manau mus irgi praleis, nes realiai niekur kitur nesugalvojau kur panaudot tokius metodus